### PR TITLE
Clone over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "kirby"]
 	path = kirby
-	url = git@github.com:getkirby/kirby.git
+	url = https://github.com/getkirby/kirby.git
 [submodule "environments/starterkit"]
 	path = environments/starterkit
-	url = git@github.com:getkirby/starterkit.git
+	url = https://github.com/getkirby/starterkit.git
 [submodule "environments/plainkit"]
 	path = environments/plainkit
-	url = git@github.com:getkirby/plainkit.git
+	url = https://github.com/getkirby/plainkit.git
 [submodule "environments/demokit"]
 	path = environments/demokit
-	url = git@github.com:getkirby/demokit.git
+	url = https://github.com/getkirby/demokit.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Kirby Sandbox is our local test environment. We use this to work on Kirby an
 
 ```console
 # clone the repo
-git clone git@github.com:getkirby/sandbox.git
+git clone https://github.com/getkirby/sandbox.git
 # step into the sandbox
 cd sandbox
 # initialize all submodules


### PR DESCRIPTION
I guess, cloning repositories will be better over HTTPS. Otherwise getting following errors. Cloning over HTTPS works great!

Failed clone due to:

> Please make sure you have the correct access rights and the repository exists

Freeze after answer following question: (even updated SSH keys)

> "Store key in cache?"

You can close the PR because maybe this is only related to my local computer, i'm not sure 🤔 