### PR TITLE
Example for section `page`  option

### DIFF
--- a/environments/lab/site/blueprints/pages/files-section.yml
+++ b/environments/lab/site/blueprints/pages/files-section.yml
@@ -138,13 +138,14 @@ tabs:
         type: files
         limit: 1
         help: This is some nice help for this files section
-      paginationNoDetails:
-        type: files
-        limit: 1
       paginationWithSearch:
         type: files
         search: true
         limit: 1
+      paginationWithPage:
+        type: files
+        limit: 1
+        page: 2
 
   widths:
     columns:

--- a/environments/lab/site/blueprints/pages/pages-section.yml
+++ b/environments/lab/site/blueprints/pages/pages-section.yml
@@ -191,13 +191,14 @@ tabs:
         type: pages
         limit: 1
         help: This is some nice help for this pages section
-      paginationNoDetails:
-        type: pages
-        limit: 1
       paginationWithSearch:
         type: pages
         search: true
         limit: 1
+      paginationWithPage:
+        type: pages
+        limit: 1
+        page: 2
 
   widths:
     columns:


### PR DESCRIPTION
https://github.com/getkirby/kirby/pull/6923

Also removes `paginationNoDetails` examples that had no different setup than the standard pagination example.