### PR TITLE
feat: Examples for nested snippets

### DIFF
--- a/environments/lab/content/other/frontend-snippets/frontend-snippets.en.txt
+++ b/environments/lab/content/other/frontend-snippets/frontend-snippets.en.txt
@@ -1,0 +1,5 @@
+Title: Frontend Snippets
+
+----
+
+Uuid: gioqdidaj3mvpoep

--- a/environments/lab/site/blueprints/pages/frontend-snippets.yml
+++ b/environments/lab/site/blueprints/pages/frontend-snippets.yml
@@ -1,0 +1,6 @@
+title: Frontend Snippets
+
+sections:
+  info:
+    type: info
+    text: "(link: other/frontend-snippets text: Visit the page) to see the snippets in action."

--- a/environments/lab/site/snippets/snippets/layout.php
+++ b/environments/lab/site/snippets/snippets/layout.php
@@ -1,0 +1,5 @@
+<!doctype html>
+
+<h1>Base layout snippet</h1>
+
+<?= $slot ?>

--- a/environments/lab/site/snippets/snippets/simple-nested.php
+++ b/environments/lab/site/snippets/snippets/simple-nested.php
@@ -1,0 +1,1 @@
+<p>c. Content from a simple snippet nested in a simple snippet.</p>

--- a/environments/lab/site/snippets/snippets/simple.php
+++ b/environments/lab/site/snippets/snippets/simple.php
@@ -1,0 +1,3 @@
+<p>b. Content from a simple snippet.</p>
+
+<?php snippet('snippets/simple-nested') ?>

--- a/environments/lab/site/snippets/snippets/slots.php
+++ b/environments/lab/site/snippets/snippets/slots.php
@@ -1,0 +1,11 @@
+<p>d. Content from a snippet that also provides slots</p>
+
+<?= $slot ?>
+
+<?= $slots->second() ?>
+
+<?php if ($foo = $slots->foo()): ?>
+	<?= $foo ?>
+<?php else: ?>
+	<p>g. Fallback content for a non-existent/unfilled slot in the snippet.</p>
+<?php endif ?>

--- a/environments/lab/site/snippets/snippets/unclosed-layout.php
+++ b/environments/lab/site/snippets/snippets/unclosed-layout.php
@@ -1,0 +1,3 @@
+<p>h. Content from a unclosed snippet's layout snippet.</p>
+
+<?= $slot ?>

--- a/environments/lab/site/snippets/snippets/unclosed-nested.php
+++ b/environments/lab/site/snippets/snippets/unclosed-nested.php
@@ -1,0 +1,1 @@
+<p>j. Content from a simple snippet nested in an unclosed snippet's default slot.</p>

--- a/environments/lab/site/snippets/snippets/unclosed.php
+++ b/environments/lab/site/snippets/snippets/unclosed.php
@@ -1,0 +1,6 @@
+<?php snippet('snippets/unclosed-layout', slots: true) ?>
+
+<p>i. Content from an unclosed snippet's default slot.</p>
+
+<?php snippet('snippets/unclosed-nested') ?>
+

--- a/environments/lab/site/templates/frontend-snippets.php
+++ b/environments/lab/site/templates/frontend-snippets.php
@@ -1,0 +1,18 @@
+<?php snippet('snippets/layout', slots: true) ?>
+
+<p>a. Some content from the template.</p>
+
+<?php snippet('snippets/simple') ?>
+
+<?php snippet('snippets/slots', slots: true) ?>
+	<?php slot() ?>
+	<p>e. Content from the tempalte in the default slot of the snippet.</p>
+	<?php endslot() ?>
+	<?php slot('second') ?>
+	<p>f. Content from the tempalte in the second slot of the snippet.</p>
+	<?php endslot() ?>
+<?php endsnippet() ?>
+
+<?php snippet('snippets/unclosed') ?>
+
+<strong>Should show headline as well as paragraphs a-j from different snippets.</strong>


### PR DESCRIPTION
Fully works with https://github.com/getkirby/kirby/pull/7599

For existing Kirby release, one needs to add an `endsnippet()` at the end of `site/snippets/snippets/unclosed.php`. This is what the PR aims to fix. 